### PR TITLE
Made ImportExcel require a compatible version

### DIFF
--- a/New-WeeklyMenu/New-WeeklyMenu.ps1
+++ b/New-WeeklyMenu/New-WeeklyMenu.ps1
@@ -41,7 +41,7 @@ function GetRecipeList {
         ".xlsx" {
             try{
                 Write-Log -linevalue "Excel file detected. Importing required modules"
-                Import-Module ImportExcel
+                Import-Module importExcel -MinimumVersion 5.0
 
                 $recipeList = Import-Excel -Path $recipeListPath -StartColumn 1 -EndColumn 4
                 


### PR DESCRIPTION
People with v4 of ImportExcel will import, but get an error since this uses the Param -StartColumn. requiring v5 fixes this issue. 